### PR TITLE
Add installOSS flag in AmbassadorInstallation.Spec

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -772,7 +772,7 @@ amb_get_image_tag() {
 # get the repository part of the image in the Ambassador deployment
 # (ie, "quay.io/datawire/aes:1.1.0" -> quay.io/datawire/aes)
 amb_get_image_repository() {
-	echo "$(amb_get_image $@)" | cut -d ":" -f1
+	echo "$(amb_get_image $@)" | rev | cut -d ":" -f2- | rev
 }
 
 # gte the list of pods of ambassador

--- a/deploy/crds/getambassador.io_ambassadorinstallations_crd.yaml
+++ b/deploy/crds/getambassador.io_ambassadorinstallations_crd.yaml
@@ -76,6 +76,18 @@ spec:
                 of values](https://github.com/helm/charts/tree/master/stable/ambassador#configuration)
                 and their default values.
               type: object
+            installOSS:
+              description: 'Installs [Ambassador OSS](https://www.getambassador.io/docs/latest/topics/install/install-ambassador-oss/)
+                instead of [AES](https://www.getambassador.io/docs/latest/topics/install/).
+                Default is false which means it installs AES by default. TODO: 1.
+                AES/AOSS is not installed and the user installs using `installOSS:
+                true`, then we straightaway install AOSS. 2. AOSS is installed via
+                operator and the user sets `installOSS: false`, then we perform the
+                migration as    detailed here - https://www.getambassador.io/docs/latest/topics/install/upgrade-to-edge-stack/
+                3. AES is installed and the user sets `installOSS: true`, then we
+                point users to the docs which gives them    pointers on how to do
+                that themselves.'
+              type: boolean
             logLevel:
               description: 'An (optional) log level: debug, info...'
               enum:

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -102,6 +102,16 @@ the last time there was a transition to this condition..</p>
   <a href="https://github.com/helm/charts/tree/master/stable/ambassador#configuration">current list of values</a>
   and their default values.</p>
 
+* `installOSS` - bool  <p>Installs <a href="https://www.getambassador.io/docs/latest/topics/install/install-ambassador-oss/">Ambassador OSS</a>
+  instead of <a href="https://www.getambassador.io/docs/latest/topics/install/">AES</a>.
+  Default is false which means it installs AES by default.
+  TODO:
+  1. AES/AOSS is not installed and the user installs using <code>installOSS: true</code>, then we straightaway install AOSS.
+  2. AOSS is installed via operator and the user sets <code>installOSS: false</code>, then we perform the migration as
+     detailed here - <a href="https://www.getambassador.io/docs/latest/topics/install/upgrade-to-edge-stack/">https://www.getambassador.io/docs/latest/topics/install/upgrade-to-edge-stack/</a>
+  3. AES is installed and the user sets <code>installOSS: true</code>, then we point users to the docs which gives them
+     pointers on how to do that themselves.</p>
+
 ## <a name="getambassador.io/v2.AmbassadorInstallationStatus">`AmbassadorInstallationStatus`
    _(Appears on:<a href="#getambassador.io/v2.AmbassadorInstallation">AmbassadorInstallation</a>)_
 

--- a/docs/using.md
+++ b/docs/using.md
@@ -122,3 +122,5 @@ force system updates to happen late at night if that’s what the sysadmins want
         - port: "80"
           host: "example"
     ```
+  * Note that, `spec.helmValues.enableAES` should not conflict with the `spec.installOSS` field or else your
+    installation will error out.

--- a/pkg/apis/getambassador/v2/ambassadorinstallation_types.go
+++ b/pkg/apis/getambassador/v2/ambassadorinstallation_types.go
@@ -68,6 +68,17 @@ type AmbassadorInstallationSpec struct {
 	// [current list of values](https://github.com/helm/charts/tree/master/stable/ambassador#configuration)
 	// and their default values.
 	HelmValues map[string]string `json:"helmValues,omitempty"`
+
+	// Installs [Ambassador OSS](https://www.getambassador.io/docs/latest/topics/install/install-ambassador-oss/)
+	// instead of [AES](https://www.getambassador.io/docs/latest/topics/install/).
+	// Default is false which means it installs AES by default.
+	// TODO:
+	// 1. AES/AOSS is not installed and the user installs using `installOSS: true`, then we straightaway install AOSS.
+	// 2. AOSS is installed via operator and the user sets `installOSS: false`, then we perform the migration as
+	//    detailed here - https://www.getambassador.io/docs/latest/topics/install/upgrade-to-edge-stack/
+	// 3. AES is installed and the user sets `installOSS: true`, then we point users to the docs which gives them
+	//    pointers on how to do that themselves.
+	InstallOSS bool `json:"installOSS,omitempty"`
 }
 
 // AmbassadorInstallationStatus defines the observed state of AmbassadorInstallation

--- a/pkg/controller/ambassadorinstallation/reconcile.go
+++ b/pkg/controller/ambassadorinstallation/reconcile.go
@@ -231,7 +231,6 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 		// configuration.
 		if len(helmValues["image.repository"]) == 0 && len(helmValues["image.tag"]) == 0 {
 			helmValues["image.repository"] = "quay.io/datawire/ambassador"
-			helmValues["image.tag"] = "1.4.2"
 		}
 	}
 

--- a/pkg/controller/ambassadorinstallation/reconcile.go
+++ b/pkg/controller/ambassadorinstallation/reconcile.go
@@ -226,7 +226,14 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 	}
 
 	if ambObj.Spec.InstallOSS {
-		helmValues["enableAES"] = "false"
+		// This is a huge HACK! The line below should have been -
+		// helmValues["enableAES"] = false
+		// but NewHelmManager and its guts only accept map[string]string which is wrong, because not all Helm values
+		// are map[string]string.
+		// However, we found out that all objects in ambObj["spec"] are passed to Helm by NewManager, so that is what
+		// this code is doing.
+		ambIns.Object["spec"].(map[string]interface{})["enableAES"] = false
+
 		// We do not want to update image.repository and image.tag if they have already been populated by user supplied
 		// configuration.
 		if len(helmValues["image.repository"]) == 0 && len(helmValues["image.tag"]) == 0 {

--- a/pkg/controller/ambassadorinstallation/reconcile.go
+++ b/pkg/controller/ambassadorinstallation/reconcile.go
@@ -205,7 +205,14 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 		(ambObj.Spec.HelmValues["enableAES"] == "true" && ambObj.Spec.InstallOSS == true) {
 		log.Info("helmValues.enableAES and installOSS fields conflict with each other",
 			"enableAES", ambObj.Spec.HelmValues["enableAES"], "installOSS", ambObj.Spec.InstallOSS)
-		return reconcile.Result{}, fmt.Errorf("helmValues.enableAES and installOSS fields conflict with each other")
+              status.SetCondition(ambassador.AmbInsCondition{
+                                  Type:    ambassador.ConditionReleaseFailed,
+                                  Status:  ambassador.StatusTrue,
+                                  Reason:  ambassador.ReasonParametersError,
+                                  Message: fmt.Sprintf("helmValues.enableAES and installOSS fields conflict with each other"),
+              })
+              _ = r.updateResourceStatus(ambIns, status)
+              return reconcile.Result{}, err
 	}
 
 	if len(ambObj.Spec.BaseImage) > 0 {

--- a/pkg/controller/ambassadorinstallation/reconcile.go
+++ b/pkg/controller/ambassadorinstallation/reconcile.go
@@ -205,14 +205,14 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 		(ambObj.Spec.HelmValues["enableAES"] == "true" && ambObj.Spec.InstallOSS == true) {
 		log.Info("helmValues.enableAES and installOSS fields conflict with each other",
 			"enableAES", ambObj.Spec.HelmValues["enableAES"], "installOSS", ambObj.Spec.InstallOSS)
-              status.SetCondition(ambassador.AmbInsCondition{
-                                  Type:    ambassador.ConditionReleaseFailed,
-                                  Status:  ambassador.StatusTrue,
-                                  Reason:  ambassador.ReasonParametersError,
-                                  Message: fmt.Sprintf("helmValues.enableAES and installOSS fields conflict with each other"),
-              })
-              _ = r.updateResourceStatus(ambIns, status)
-              return reconcile.Result{}, fmt.Errorf("helmValues.enableAES and installOSS fields conflict with each other")
+		status.SetCondition(ambassador.AmbInsCondition{
+			Type:    ambassador.ConditionReleaseFailed,
+			Status:  ambassador.StatusTrue,
+			Reason:  ambassador.ReasonParametersError,
+			Message: fmt.Sprintf("helmValues.enableAES and installOSS fields conflict with each other"),
+		})
+		_ = r.updateResourceStatus(ambIns, status)
+		return reconcile.Result{}, fmt.Errorf("helmValues.enableAES and installOSS fields conflict with each other")
 	}
 
 	if len(ambObj.Spec.BaseImage) > 0 {

--- a/pkg/controller/ambassadorinstallation/reconcile.go
+++ b/pkg/controller/ambassadorinstallation/reconcile.go
@@ -212,7 +212,7 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
                                   Message: fmt.Sprintf("helmValues.enableAES and installOSS fields conflict with each other"),
               })
               _ = r.updateResourceStatus(ambIns, status)
-              return reconcile.Result{}, err
+              return reconcile.Result{}, fmt.Errorf("helmValues.enableAES and installOSS fields conflict with each other")
 	}
 
 	if len(ambObj.Spec.BaseImage) > 0 {

--- a/tests/e2e/tests/05-install-oss.sh
+++ b/tests/e2e/tests/05-install-oss.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+[ -d "$this_dir" ] || {
+	echo "FATAL: no current dir (maybe running in zsh?)"
+	exit 1
+}
+TOP_DIR=$(realpath $this_dir/../../..)
+
+# shellcheck source=../common.sh
+source "$this_dir/../common.sh"
+
+########################################################################################################################
+# local variables
+########################################################################################################################
+
+# the versions of Ambassador to install
+IMAGE_REPOSITORY="quay.io/datawire/ambassador"
+
+########################################################################################################################
+
+[ -z "$DEV_REGISTRY" ] && abort "no DEV_REGISTRY defined"
+[ -z "$KUBECONFIG" ] && abort "no KUBECONFIG defined"
+
+########################################################################################################################
+
+info "Installing the Operator..."
+oper_install "yaml" "$TEST_NAMESPACE" || failed "could not deploy operator"
+oper_wait_install -n "$TEST_NAMESPACE" || failed "the Ambassador operator is not alive"
+
+info "Installing Ambassador..."
+
+info "Creating AmbassadorInstallation with 'installOSS: true'..."
+apply_amb_inst_oss -n "$TEST_NAMESPACE"
+info "AmbassadorInstallation created successfully..."
+
+info "Waiting for the Operator to install Ambassador"
+if ! wait_amb_addr -n "$TEST_NAMESPACE"; then
+	warn "Ambassador not installed. Dumping Operator's logs:"
+	oper_logs_dump -n "$TEST_NAMESPACE"
+	failed "could not get an Ambassador IP"
+fi
+passed "... good! Ambassador has been installed by the Operator!"
+
+[ -n "$VERBOSE" ] && {
+	info "Describe: Ambassador Operator deployment:" && oper_describe -n "$TEST_NAMESPACE"
+	info "Describe: Ambassador deployment:" && amb_describe -n "$TEST_NAMESPACE"
+}
+
+info "Checking the repository of Ambassador that has been deployed is $IMAGE_REPOSITORY..."
+if ! amb_check_image_repository "$IMAGE_REPOSITORY" -n "$TEST_NAMESPACE"; then
+	warn "Image not expected. Dumping Operator's logs:"
+	oper_logs_dump -n "$TEST_NAMESPACE"
+	failed "wrong version installed"
+fi
+passed "... good! Ambassador that has been deployed with $IMAGE_REPOSITORY"
+
+info "Ambassador OSS should not install any AuthServices in namespace $TEST_NAMESPACE, checking..."
+if ! kube_check_resource_empty "authservices" -n "$TEST_NAMESPACE"; then
+    info "AuthServices are present in the namespace $TEST_NAMESPACE"
+    failed "OSS should not have AuthService installed in namespace $TEST_NAMESPACE"
+fi
+passed "... good! AuthServices are not present in the namespace $TEST_NAMESPACE"
+
+amb_inst_check_success -n "$TEST_NAMESPACE" || {
+	warn "Unexpected content in AmbassadorInstallation description:"
+	amb_inst_describe -n "$TEST_NAMESPACE"
+	failed "Success not found in AmbassadorInstallation description"
+}
+
+[ -n "$VERBOSE" ] && {
+	info "Describe: AmbassadorInstallation:" && amb_inst_describe -n "$TEST_NAMESPACE"
+	info "Logs: Ambassador operator" && oper_logs_dump -n "$TEST_NAMESPACE"
+}
+
+exit 0


### PR DESCRIPTION
Installs [Ambassador OSS](https://www.getambassador.io/docs/latest/topics/install/install-ambassador-oss/)
instead of [AES](https://www.getambassador.io/docs/latest/topics/install/).

Default is false which means it installs AES by default.