### PR TITLE
Backwards compatibility in the helmValues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ test: ## Run the Go tests
 
 $(AMB_COVERAGE_FILE): test
 
-e2e: ## Run the e2e tests. options: VERBOSE=1, TEST=<some-test.sh>
+e2e: ## Run the e2e tests -- VERBOSE=1, TEST=<some-test.sh>, CLUSTER_KEEP=1
 	@echo ">>> Running e2e tests"
 	$(Q)AMB_OPER_IMAGE=$(AMB_OPER_IMAGE) ./tests/e2e/runner.sh \
 		--image-name=$(AMB_OPER_BASE_IMAGE) --image-tag=$(AMB_OPER_TAG) check $(TEST)

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -264,7 +264,8 @@ get_amb_addr() {
 	if [ -n "$AMB_EXT_ADDR" ]; then
 		echo "$AMB_EXT_ADDR"
 	else
-		kubectl get $@ service ambassador -o 'go-template={{range .status.loadBalancer.ingress}}{{print .ip "\n"}}{{end}}' 2>/dev/null
+		kubectl get $@ service ambassador \
+		    -o 'go-template={{range .status.loadBalancer.ingress}}{{print .ip "\n"}}{{end}}' 2>/dev/null
 	fi
 }
 
@@ -279,10 +280,10 @@ wait_amb_addr() {
 		sleep 1
 	done
 
-	if [ $i -gt $timeout ]; then
+	if [ $i -ge $timeout ]; then
 		warn "Timeout waiting for Ambassador's IP. Current services:"
-		kubectl get services
-		abort "Ambassador did get not an IP after $timeout seconds"
+		kubectl get services $@
+		abort "Ambassador did not get an IP after $timeout seconds"
 	fi
 }
 
@@ -297,9 +298,9 @@ wait_not_amb_addr() {
 		sleep 1
 	done
 
-	if [ $i -gt $timeout ]; then
+	if [ $i -ge $timeout ]; then
 		warn "Timeout waiting for Ambassador not not have an IP. Current services:"
-		kubectl get services
+		kubectl get services $@
 		abort "Ambassador had an IP after $timeout seconds"
 	fi
 }


### PR DESCRIPTION
We must be able to detect and parse old-style assignments in the `helmValues` like `service.ports[0].port: 80`. With this PR, if a _dot_ is detected then we use the old parsing.

For example, this is valid:

```yaml
apiVersion: getambassador.io/v2
kind: AmbassadorInstallation
metadata:
  name: ambassador
spec:
  version: "*"
  logLevel: info
  helmValues:
    namespace:
      name: ambassador
    image:
      pullPolicy: Always
    service.ports[0].name: http
    service.ports[0].port: 80
    service.ports[0].targetPort: 8080
```

and will be equivalent to these `values.yaml`:

```yaml
image:
  pullPolicy: Always
namespace:
  name: ambassador
service:
  ports:
  - name: http
    port: "80"
    targetPort: "8080"
```