### PR TITLE
Fixes in the reconciliation code and helm values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,9 @@ HELM_OPER_MANIF      = $(HELM_DIR)/templates/ambassador-operator.yaml
 IMAGE_EXTRA_FILE         ?=
 IMAGE_EXTRA_FILE_CONTENT ?=
 
-REL_REGISTRY        ?= quay.io/datawire
+REL_REGISTRY        ?= docker.io/datawire
 REL_AMB_OPER_IMAGE   = $(REL_REGISTRY)/$(AMB_OPER_IMAGE)
+export REL_REGISTRY
 
 # directory for docs
 DOCS_API_DIR         := docs/api
@@ -73,7 +74,7 @@ DOCS_API_DIR         := docs/api
 AMB_OPER_CHART_VALS  := $(TOP_DIR)/deploy/helm/ambassador-operator/values.yaml
 
 # Go flags
-GO_FLAGS             =
+GO_FLAGS             = -ldflags="-X pkg.controller.ambassadorinstallation.DefRegistry=$(REL_REGISTRY)"
 
 # shfmt flags
 SHFMT_ARGS           = -s -ln bash

--- a/pkg/controller/ambassadorinstallation/charts_test.go
+++ b/pkg/controller/ambassadorinstallation/charts_test.go
@@ -2,9 +2,61 @@ package ambassadorinstallation
 
 import (
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func TestRemoteChartDownload(t *testing.T) {
-	// TODO
+func TestHelmValues(t *testing.T) {
+	ambIns := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"helmValues": map[string]interface{}{
+					"deploymentTool": "amb-oper-kind",
+				},
+			},
+		},
+	}
+
+	hv := GetHelmValuesAmbIns(ambIns)
+	res, found, err := hv.GetString("deploymentTool")
+	if err != nil {
+		t.Errorf("error while looking for deploymentTool: %v", err)
+	}
+	if !found {
+		t.Errorf("deploymentTool not found")
+	}
+	if res != "amb-oper-kind" {
+		t.Errorf("deploymentTool %q does not match expected values 'amb-oper-kind'", res)
+	}
+
+	// add some new helmValues, overwriting some of the old ones
+	newHelmValues := map[string]interface{}{
+		"deploymentTool":   "amb-oper-manifest",
+		"image.repository": "somewhere",
+	}
+	hv.AppendFrom(newHelmValues, true)
+
+	res, found, err = hv.GetString("deploymentTool")
+	if err != nil {
+		t.Errorf("error while looking for deploymentTool: %v", err)
+	}
+	if !found {
+		t.Errorf("deploymentTool not found")
+	}
+	if res != "amb-oper-manifest" {
+		t.Errorf("deploymentTool %q does not match expected values 'amb-oper-manifest'", res)
+	}
+
+	res, found, err = hv.GetString("image.repository")
+	if err != nil {
+		t.Errorf("error while looking for image.repository: %v", err)
+	}
+	if !found {
+		t.Errorf("image.repository not found")
+	}
+	if res != "somewhere" {
+		t.Errorf("image.repository %q does not match expected values 'somewhere'", res)
+	}
+
 	return
 }

--- a/pkg/controller/ambassadorinstallation/const.go
+++ b/pkg/controller/ambassadorinstallation/const.go
@@ -1,0 +1,8 @@
+package ambassadorinstallation
+
+var (
+	// DefRegistry is the default registry
+	// note: this value can overwritten from the environment when compiling
+	// TODO: we could obtain the value from the image of the operator's Deployment maybe?
+	DefRegistry = "docker.io/datawire"
+)

--- a/pkg/controller/ambassadorinstallation/files.go
+++ b/pkg/controller/ambassadorinstallation/files.go
@@ -14,8 +14,9 @@ var (
 	errParseError = errors.New("error when parsing YAML")
 )
 
-func readValues(in []byte) (HelmValuesStrings, error) {
-	var output HelmValuesStrings
+// readValues unserializes a values file
+func readValues(in []byte) (HelmValues, error) {
+	var output HelmValues
 
 	if err := yaml.Unmarshal(in, &output); err != nil {
 		return nil, fmt.Errorf("%w: %s", errParseError, in)
@@ -23,7 +24,8 @@ func readValues(in []byte) (HelmValuesStrings, error) {
 	return output, nil
 }
 
-func readValuesFile(file string) (HelmValuesStrings, error) {
+// readValuesFile reads a values.yaml file from disk
+func readValuesFile(file string) (HelmValues, error) {
 	if !fileExists(file) {
 		return nil, errFileDoesNotExist
 	}

--- a/pkg/controller/ambassadorinstallation/reconcile.go
+++ b/pkg/controller/ambassadorinstallation/reconcile.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/datawire/ambassador/pkg/helm"
+
 	rpb "helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,8 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/datawire/ambassador/pkg/helm"
 
 	ambassador "github.com/datawire/ambassador-operator/pkg/apis/getambassador/v2"
 )
@@ -45,7 +45,7 @@ const (
 
 var (
 	// some default Helm values
-	defaultChartValues = map[string]string{
+	defaultChartValues = HelmValues{
 		"deploymentTool": "amb-oper",
 	}
 
@@ -90,9 +90,6 @@ type ReconcileAmbassadorInstallation struct {
 	checkInterval      time.Duration
 	updateInterval     time.Duration
 	lastSucUpdateCheck time.Time
-
-	flavor      string
-	isMigrating bool
 }
 
 func NewReconcileAmbassadorInstallation(mgr manager.Manager) *ReconcileAmbassadorInstallation {
@@ -144,7 +141,7 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 
 	spec := ambObj.Spec
 	status := ambassador.StatusFor(ambIns)
-	specHelmValues := GetHelmValuesFrom(ambIns) // values passes in the spec: just for reading
+	specHelmValues := GetHelmValuesAmbIns(ambIns) // values passes in the spec: just for reading
 
 	// check if this AmbassadorInstallation was marked as a Duplicate in the past
 	lastDuplicateCondition := status.LastCondition(ambassador.AmbInsCondition{Reason: ambassador.ReasonDuplicateError})
@@ -188,12 +185,10 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 	})
 	status.RemoveCondition(ambassador.ConditionIrreconcilable)
 
-	helmValuesStrings := HelmValuesStrings{}
+	// process all static Helm values: the default ones, the ones coming from files, etc...
+	helmValues := HelmValues{}
+	helmValues.AppendFrom(defaultChartValues, true) // copy the default values
 
-	// copy all the values, both from the default values as from the user provided ones
-	for k, v := range defaultChartValues {
-		helmValuesStrings[k] = v
-	}
 	for _, f := range defExtraValuesFiles {
 		log.Info("Trying to load values from file", "file", f)
 		values, err := readValuesFile(f)
@@ -201,10 +196,11 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 			log.Info("Error when loading file", "file", f, "error", err)
 			continue
 		}
-		for k, v := range values {
-			log.Info("Settings value from file", "file", f, "var", k, "value", v)
-			helmValuesStrings[k] = v
-		}
+		helmValues.AppendFrom(values, true)
+	}
+	if err := helmValues.WriteToAmbIns(ambIns, false); err != nil {
+		reqLogger.Info("Internal error when adding static helm values: %v", err)
+		return reconcile.Result{}, err
 	}
 
 	// `enableAES: true` means `installOSS: false`
@@ -228,6 +224,8 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 		}
 	}
 
+	helmValuesStrings := HelmValuesStrings{} // high-precedence values: they will override any other values
+
 	if len(spec.BaseImage) > 0 {
 		repo, tag, err := parseRepoTag(spec.BaseImage)
 		if err != nil {
@@ -245,7 +243,19 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 		helmValuesStrings["image.tag"] = tag
 	}
 
+	flavor := ""
+	isMigrating := false
+
 	if enableOSS {
+		// Check user is not trying to migrate from AES to OSS...
+		if status.DeployedRelease != nil {
+			if status.DeployedRelease.Flavor != flavorOSS {
+				err = fmt.Errorf("migration from AES to OSS not supported")
+				log.Error(err, "")
+				return reconcile.Result{}, err
+			}
+		}
+
 		// This is a huge HACK! The line below should have been -
 		// helmValues["enableAES"] = false
 		// but NewHelmManager and its guts only accept map[string]string which is wrong, because not all Helm values
@@ -265,13 +275,17 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 			helmValuesStrings["image.repository"] = defOSSImageRepository
 		}
 
-		r.flavor = flavorOSS
+		flavor = flavorOSS
+		reqLogger.Info("Flavor: OSS")
+
 	} else {
 		if status.DeployedRelease != nil {
-			// if AES is already installed, then we don't need to look for AuthService or RateLimitService
-			log.Info("AuthService or RateLimitService must not exist in the cluster while upgrading from OSS to AES...")
-
 			if status.DeployedRelease.Flavor != flavorAES {
+				log.Info("Upgrading the cluster from OSS to AES...")
+
+				// if AES is already installed, then we don't need to look for AuthService or RateLimitService
+				log.Info("Checking that AuthService/RateLimitService do not exist in the cluster.")
+
 				log.Info("Checking for AuthService...")
 				authServiceList, err := r.lookupResourceList(&schema.GroupVersionKind{
 					Group:   "getambassador.io",
@@ -303,11 +317,13 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 					log.Error(err, "")
 					return reconcile.Result{}, err
 				}
+
+				isMigrating = true
 			}
-			r.isMigrating = true
 		}
-		r.flavor = flavorAES
-		reqLogger.Info("AES: enabled")
+
+		flavor = flavorAES
+		reqLogger.Info("Flavor: AES")
 	}
 
 	if len(spec.LogLevel) > 0 {
@@ -365,7 +381,7 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	return r.tryInstallOrUpdate(ambIns, chartsMgr, window)
+	return r.tryInstallOrUpdate(ambIns, chartsMgr, window, isMigrating, flavor)
 }
 
 func (r *ReconcileAmbassadorInstallation) updateResource(o runtime.Object) error {

--- a/pkg/controller/ambassadorinstallation/reconcile.go
+++ b/pkg/controller/ambassadorinstallation/reconcile.go
@@ -36,9 +36,6 @@ const (
 	// controller name for the events recorder
 	defControllerName = "ambassador-controller"
 
-	// default image used for the OSS version
-	defOSSImageRepository = "quay.io/datawire/ambassador"
-
 	// OSS flavor to set in DeployedRelease.flavor
 	flavorOSS = "OSS"
 
@@ -51,6 +48,9 @@ var (
 	defaultChartValues = map[string]string{
 		"deploymentTool": "amb-oper",
 	}
+
+	// default image used for the OSS version
+	defOSSImageRepository = fmt.Sprintf("%s/ambassador", DefRegistry)
 
 	// defExtraValuesFiles defines a list of files where we can find extra values
 	// NOTE: values in the last files will overwrite values in previous files!

--- a/pkg/controller/ambassadorinstallation/reconcile_update.go
+++ b/pkg/controller/ambassadorinstallation/reconcile_update.go
@@ -32,7 +32,8 @@ const (
 )
 
 // tryInstallOrUpdate checks if we need to update the Helm chart
-func (r *ReconcileAmbassadorInstallation) tryInstallOrUpdate(ambObj *unstructured.Unstructured, chartsMgr HelmManager, window UpdateWindow) (reconcile.Result, error) {
+func (r *ReconcileAmbassadorInstallation) tryInstallOrUpdate(ambObj *unstructured.Unstructured,
+	chartsMgr HelmManager, window UpdateWindow, isMigrating bool, flavor string) (reconcile.Result, error) {
 	updateDeadline := time.Now().Add(defaultUpdateTimeout)
 	ctx, _ := context.WithDeadline(context.TODO(), updateDeadline)
 
@@ -48,7 +49,7 @@ func (r *ReconcileAmbassadorInstallation) tryInstallOrUpdate(ambObj *unstructure
 	// try to install/upgrade in any other case (ie, the initial installation, the deployment
 	// is in an error state, etc)
 	// We ignore this upgrade check when OSS to AES migration is set in AmbassadorInstallation
-	if (currCondition.Type == ambassador.ConditionDeployed) && !r.isMigrating {
+	if (currCondition.Type == ambassador.ConditionDeployed) && !isMigrating {
 		if !status.LastCheckTime.Time.IsZero() && now.Sub(status.LastCheckTime.Time) < r.updateInterval {
 			log.Info("Last install/update was not so long ago", "updateInterval", r.updateInterval)
 			return reconcile.Result{RequeueAfter: r.checkInterval}, nil
@@ -145,7 +146,7 @@ func (r *ReconcileAmbassadorInstallation) tryInstallOrUpdate(ambObj *unstructure
 			Version:    installedRelease.Chart.Metadata.Version,
 			AppVersion: installedRelease.Chart.Metadata.AppVersion,
 			Manifest:   installedRelease.Manifest,
-			Flavor:     r.flavor,
+			Flavor:     flavor,
 		}
 
 		err = r.updateResourceStatus(ambObj, status)
@@ -206,7 +207,7 @@ func (r *ReconcileAmbassadorInstallation) tryInstallOrUpdate(ambObj *unstructure
 			Version:    updatedRelease.Chart.Metadata.Version,
 			AppVersion: updatedRelease.Chart.Metadata.AppVersion,
 			Manifest:   updatedRelease.Manifest,
-			Flavor:     r.flavor,
+			Flavor:     flavor,
 		}
 		err = r.updateResourceStatus(ambObj, status)
 		return reconcile.Result{RequeueAfter: r.checkInterval}, err
@@ -247,7 +248,7 @@ func (r *ReconcileAmbassadorInstallation) tryInstallOrUpdate(ambObj *unstructure
 		Version:    expectedRelease.Chart.Metadata.Version,
 		AppVersion: expectedRelease.Chart.Metadata.AppVersion,
 		Manifest:   expectedRelease.Manifest,
-		Flavor:     r.flavor,
+		Flavor:     flavor,
 	}
 	_ = r.updateResourceStatus(ambObj, status)
 	return reconcile.Result{RequeueAfter: r.checkInterval}, nil

--- a/tests/e2e/common.sh
+++ b/tests/e2e/common.sh
@@ -17,3 +17,6 @@ TESTSUITES_DIR="$tests_dir/tests"
 
 # namespace for runing tests
 TEST_NAMESPACE="$AMB_NAMESPACE"
+
+# the default regitry
+REL_REGISTRY="${REL_REGISTRY:-docker.io/datawire}"

--- a/tests/e2e/tests/02-custom-image.sh
+++ b/tests/e2e/tests/02-custom-image.sh
@@ -14,8 +14,8 @@ source "$this_dir/../common.sh"
 # local variables
 ########################################################################################################################
 
-CUSTOM_IMAGE_FIRST="quay.io/datawire/aes:1.3.0"
-CUSTOM_IMAGE_SECOND="quay.io/datawire/aes:1.4.0"
+CUSTOM_IMAGE_FIRST="${REL_REGISTRY}/aes:1.3.0"
+CUSTOM_IMAGE_SECOND="${REL_REGISTRY}/aes:1.4.0"
 
 # the versions of Ambassador to install
 IMAGE_TAG_FIRST="1.3.0"

--- a/tests/e2e/tests/05-install-oss.sh
+++ b/tests/e2e/tests/05-install-oss.sh
@@ -15,7 +15,7 @@ source "$this_dir/../common.sh"
 ########################################################################################################################
 
 # the versions of Ambassador to install
-IMAGE_REPOSITORY="quay.io/datawire/ambassador"
+IMAGE_REPOSITORY="${REL_REGISTRY}/ambassador"
 
 ########################################################################################################################
 

--- a/tests/e2e/tests/07-migrate-oss-aes.sh
+++ b/tests/e2e/tests/07-migrate-oss-aes.sh
@@ -15,8 +15,8 @@ source "$this_dir/../common.sh"
 ########################################################################################################################
 
 # the versions of Ambassador to install
-IMAGE_REPOSITORY="quay.io/datawire/ambassador"
-AES_IMAGE_REPOSITORY="quay.io/datawire/aes"
+IMAGE_REPOSITORY="${REL_REGISTRY}/ambassador"
+AES_IMAGE_REPOSITORY="${REL_REGISTRY}/aes"
 
 ########################################################################################################################
 

--- a/tests/e2e/tests/08-migration-oss-aes-fail.sh
+++ b/tests/e2e/tests/08-migration-oss-aes-fail.sh
@@ -15,8 +15,8 @@ source "$this_dir/../common.sh"
 ########################################################################################################################
 
 # the versions of Ambassador to install
-IMAGE_REPOSITORY="quay.io/datawire/ambassador"
-AES_IMAGE_REPOSITORY="quay.io/datawire/aes"
+IMAGE_REPOSITORY="${REL_REGISTRY}/ambassador"
+AES_IMAGE_REPOSITORY="${REL_REGISTRY}/aes"
 
 ########################################################################################################################
 


### PR DESCRIPTION
Fixes in _helmValues_ and reconciliation:
    
 * The reconciliation was saving the latest migration/flavor in a _"global"_ variable, so the reconciler always thought it was reconciling.
* _helmValues_ in files were having more precedence than values provided in `.spec.helmValues`. Fixed this problem by copying the values in these files to `.spec.helmValues`.
* Make the registry something configurable (so we can use `docker.io` instead of `quay.io`)

