### PR TITLE
Fix deletions

### DIFF
--- a/pkg/controller/ambassadorinstallation/charts.go
+++ b/pkg/controller/ambassadorinstallation/charts.go
@@ -80,8 +80,7 @@ type HelmValuesStrings map[string]string
 
 // HelmManager is a remote Helm repo or a file, provided with an URL
 type HelmManager struct {
-	mgr    manager.Manager
-	Values HelmValuesStrings
+	mgr manager.Manager
 	helm.HelmDownloader
 }
 
@@ -93,27 +92,26 @@ type HelmManagerOptions struct {
 // NewHelmManager creates a new charts manager
 // The Helm Manager will use the URL provided, and download (lazily) a Chart that
 // obeys the Version Rule.
-func NewHelmManager(options HelmManagerOptions, values HelmValuesStrings) (HelmManager, error) {
+func NewHelmManager(options HelmManagerOptions) (HelmManager, error) {
 	downloader, err := helm.NewHelmDownloader(options.HelmDownloaderOptions)
 	if err != nil {
 		return HelmManager{}, err
 	}
 	return HelmManager{
 		mgr:            options.Manager,
-		Values:         values,
 		HelmDownloader: downloader,
 	}, nil
 }
 
 // GetManagerFor returns a helm chart manager for the chart we have downloaded
-func (lc *HelmManager) GetManagerFor(o *unstructured.Unstructured) (release.Manager, error) {
+func (lc *HelmManager) GetManagerFor(o *unstructured.Unstructured, values HelmValuesStrings) (release.Manager, error) {
 	factory := release.NewManagerFactory(lc.mgr, lc.DownChartDir)
 
 	// create a copy of the object. we will use this one for creating the manager.
 	var oc unstructured.Unstructured
 	o.DeepCopyInto(&oc)
 
-	valuesStrings := lc.Values
+	valuesStrings := values
 
 	// hack for allowing any type in the helmValues:
 	// translate all the `.spec.helmValues.*` to `.spec.*`, so factory.NewManager

--- a/pkg/controller/ambassadorinstallation/reconcile_delete.go
+++ b/pkg/controller/ambassadorinstallation/reconcile_delete.go
@@ -51,7 +51,7 @@ func (r *ReconcileAmbassadorInstallation) deleteRelease(o *unstructured.Unstruct
 	}
 	defer func() { _ = chartsMgr.Cleanup() }()
 
-	manager, err := chartsMgr.GetManagerFor(o)
+	manager, err := chartsMgr.GetManagerFor(o, HelmValuesStrings{})
 	defer func() { _ = chartsMgr.Cleanup() }()
 	if err != nil {
 		return reconcile.Result{}, err

--- a/tests/e2e/tests/01-install-uninstall.sh
+++ b/tests/e2e/tests/01-install-uninstall.sh
@@ -113,7 +113,7 @@ amb_inst_check_success -n "$TEST_NAMESPACE" || {
 }
 
 info "Checking we can remove Ambassador when the AmbassadorInstallation is deleted"
-amb_inst_delete -n "$TEST_NAMESPACE" || failed "could not remove AmbassadorInstallation"
+amb_inst_delete -n "$TEST_NAMESPACE" || failed "could not remove AmbassadorInstallations"
 
 sleep 5
 

--- a/tests/e2e/tests/04-helm-install-uninstall.sh
+++ b/tests/e2e/tests/04-helm-install-uninstall.sh
@@ -77,7 +77,7 @@ amb_inst_check_success -n "$TEST_NAMESPACE" || failed "Success not found in Amba
 }
 
 info "Checking we can remove Ambassador when the AmbassadorInstallation is deleted"
-amb_inst_delete -n "$TEST_NAMESPACE" || failed "could not remove AmbassadorInstallation"
+amb_inst_delete -n "$TEST_NAMESPACE" || failed "could not remove the AmbassadorInstallations"
 
 sleep 5
 


### PR DESCRIPTION
* We were processing errors before processing the deletion of an `AmbassadorInstallation`. That meant that an errored `AmbassadorInstallation` could not be deleted.
* Do not try to check the existence of a `AuthService`/`RateLimitService` (that prevents a migration) until we are about to migrate.
* Cleanups were not working because we were not removing all the `AmbassadorInstallations`.
* Simplify some code in the tests.
