### PR TITLE
Do not delay reinstalls/updates when .spec changes are detected

### DIFF
--- a/pkg/controller/ambassadorinstallation/comp.go
+++ b/pkg/controller/ambassadorinstallation/comp.go
@@ -1,0 +1,66 @@
+package ambassadorinstallation
+
+import (
+	"errors"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var (
+	errNoPrevConfigFound = errors.New("no previous configuration found")
+)
+
+// hasChangedSpec returns True iff the AmbassadorInstallation has a previous
+// .spec recorded and the current .spec is different.
+func hasChangedSpec(o *unstructured.Unstructured) bool {
+	log.Info("Comparing changes with previously applied configuration")
+
+	prev, err := getPreviousApplied(o)
+	if err == errNoPrevConfigFound {
+		log.Info("AmbassadorInstallation was not applied before")
+		return false
+	}
+	if err != nil {
+		log.Error(err, "when trying to check previous spec")
+		return false
+	}
+
+	currSpec, found, err := unstructured.NestedFieldNoCopy(o.Object, "spec")
+	if !found {
+		log.Error(err, "No .spec found in current AmbassadorInstallation")
+		return false
+	}
+	if err != nil {
+		log.Error(err, "when trying to get current .spec")
+		return false
+	}
+
+	prevSpec, found, err := unstructured.NestedFieldNoCopy(prev.Object, "spec")
+	if !found {
+		log.Error(err, "No .spec found in previous AmbassadorInstallation")
+		return false
+	}
+	if err != nil {
+		log.Error(err, "when trying to get previous .spec")
+		return false
+	}
+
+	return !reflect.DeepEqual(prevSpec, currSpec)
+}
+
+// getPreviousApplied returns the previously applied configuration
+func getPreviousApplied(o *unstructured.Unstructured) (unstructured.Unstructured, error) {
+	const previousAppliedAnnot = "kubectl.kubernetes.io/last-applied-configuration"
+	prevStr, found := o.GetAnnotations()[previousAppliedAnnot]
+	if !found {
+		return unstructured.Unstructured{}, errNoPrevConfigFound
+	}
+
+	prev := unstructured.Unstructured{}
+	_, _, err := unstructured.UnstructuredJSONScheme.Decode([]byte(prevStr), nil, &prev)
+	if err != nil {
+		return unstructured.Unstructured{}, err
+	}
+	return prev, nil
+}

--- a/pkg/controller/ambassadorinstallation/comp_test.go
+++ b/pkg/controller/ambassadorinstallation/comp_test.go
@@ -1,0 +1,206 @@
+package ambassadorinstallation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestHasChangedSpec(t *testing.T) {
+
+	stringToUnstr := func(data string) *unstructured.Unstructured {
+		unstruct := &unstructured.Unstructured{}
+		_, _, err := unstructured.UnstructuredJSONScheme.Decode([]byte(data), nil, unstruct)
+		if err != nil {
+			panic("could not decode data")
+		}
+		return unstruct
+	}
+
+	// obtained with:
+	// kubectl get ambassadorinstallations -n ambassador ambassador -o json
+
+	tests := []struct {
+		description string
+		instance    *unstructured.Unstructured
+		hasChanged  bool
+	}{
+		{
+			description: "configuration has not changed",
+			instance: stringToUnstr(`
+{
+    "apiVersion": "getambassador.io/v2",
+    "kind": "AmbassadorInstallation",
+    "metadata": {
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"AmbassadorInstallation\",\"metadata\":{\"annotations\":{},\"name\":\"ambassador\",\"namespace\":\"ambassador\"},\"spec\":{\"helmValues\":{\"image\":{\"pullPolicy\":\"Always\"},\"namespace\":{\"name\":\"ambassador\"},\"service\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"targetPort\":8080}],\"type\":\"NodePort\"}},\"version\":\"1.*\"}}\n"
+        },
+        "creationTimestamp": "2020-05-28T09:12:59Z",
+        "generation": 1,
+        "name": "ambassador",
+        "namespace": "ambassador",
+        "resourceVersion": "1586",
+        "selfLink": "/apis/getambassador.io/v2/namespaces/ambassador/ambassadorinstallations/ambassador",
+        "uid": "f5e70521-837b-4891-84c1-2e713ae6e3da"
+    },
+    "spec": {
+        "helmValues": {
+            "image": {
+                "pullPolicy": "Always"
+            },
+            "namespace": {
+                "name": "ambassador"
+            },
+            "service": {
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": 80,
+                        "targetPort": 8080
+                    }
+                ],
+                "type": "NodePort"
+            }
+        },
+        "version": "1.*"
+    }
+}
+`),
+			hasChanged: false,
+		},
+		{
+			description: "changed version number to 2.*",
+			instance: stringToUnstr(`
+{
+    "apiVersion": "getambassador.io/v2",
+    "kind": "AmbassadorInstallation",
+    "metadata": {
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"AmbassadorInstallation\",\"metadata\":{\"annotations\":{},\"name\":\"ambassador\",\"namespace\":\"ambassador\"},\"spec\":{\"helmValues\":{\"image\":{\"pullPolicy\":\"Always\"},\"namespace\":{\"name\":\"ambassador\"},\"service\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"targetPort\":8080}],\"type\":\"NodePort\"}},\"version\":\"1.*\"}}\n"
+        },
+        "creationTimestamp": "2020-05-28T09:12:59Z",
+        "generation": 1,
+        "name": "ambassador",
+        "namespace": "ambassador",
+        "resourceVersion": "1586",
+        "selfLink": "/apis/getambassador.io/v2/namespaces/ambassador/ambassadorinstallations/ambassador",
+        "uid": "f5e70521-837b-4891-84c1-2e713ae6e3da"
+    },
+    "spec": {
+        "helmValues": {
+            "image": {
+                "pullPolicy": "Always"
+            },
+            "namespace": {
+                "name": "ambassador"
+            },
+            "service": {
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": 80,
+                        "targetPort": 8080
+                    }
+                ],
+                "type": "NodePort"
+            }
+        },
+        "version": "2.*"
+    }
+}
+`),
+			hasChanged: true,
+		},
+		{
+			description: "changed image.pullpolicy",
+			instance: stringToUnstr(`
+{
+    "apiVersion": "getambassador.io/v2",
+    "kind": "AmbassadorInstallation",
+    "metadata": {
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"AmbassadorInstallation\",\"metadata\":{\"annotations\":{},\"name\":\"ambassador\",\"namespace\":\"ambassador\"},\"spec\":{\"helmValues\":{\"image\":{\"pullPolicy\":\"Always\"},\"namespace\":{\"name\":\"ambassador\"},\"service\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"targetPort\":8080}],\"type\":\"NodePort\"}},\"version\":\"1.*\"}}\n"
+        },
+        "creationTimestamp": "2020-05-28T09:12:59Z",
+        "generation": 1,
+        "name": "ambassador",
+        "namespace": "ambassador",
+        "resourceVersion": "1586",
+        "selfLink": "/apis/getambassador.io/v2/namespaces/ambassador/ambassadorinstallations/ambassador",
+        "uid": "f5e70521-837b-4891-84c1-2e713ae6e3da"
+    },
+    "spec": {
+        "helmValues": {
+            "image": {
+                "pullPolicy": "Never"
+            },
+            "namespace": {
+                "name": "ambassador"
+            },
+            "service": {
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": 80,
+                        "targetPort": 8080
+                    }
+                ],
+                "type": "NodePort"
+            }
+        },
+        "version": "1.*"
+    }
+}
+`),
+			hasChanged: true,
+		},
+		{
+			description: "no previous configuration",
+			instance: stringToUnstr(`
+{
+    "apiVersion": "getambassador.io/v2",
+    "kind": "AmbassadorInstallation",
+    "metadata": {
+        "creationTimestamp": "2020-05-28T09:12:59Z",
+        "generation": 1,
+        "name": "ambassador",
+        "namespace": "ambassador",
+        "resourceVersion": "1586",
+        "selfLink": "/apis/getambassador.io/v2/namespaces/ambassador/ambassadorinstallations/ambassador",
+        "uid": "f5e70521-837b-4891-84c1-2e713ae6e3da"
+    },
+    "spec": {
+        "helmValues": {
+            "image": {
+                "pullPolicy": "Never"
+            },
+            "namespace": {
+                "name": "ambassador"
+            },
+            "service": {
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": 80,
+                        "targetPort": 8080
+                    }
+                ],
+                "type": "NodePort"
+            }
+        },
+        "version": "1.*"
+    }
+}
+`),
+			hasChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			if got := hasChangedSpec(tt.instance); got != tt.hasChanged {
+				t.Errorf("hasChangedSpec() = %v, want %v, when %s", got, tt.hasChanged, tt.description)
+			}
+		})
+	}
+}

--- a/pkg/controller/ambassadorinstallation/reconcile.go
+++ b/pkg/controller/ambassadorinstallation/reconcile.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/datawire/ambassador/pkg/helm"
-
 	rpb "helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,6 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/datawire/ambassador/pkg/helm"
 
 	ambassador "github.com/datawire/ambassador-operator/pkg/apis/getambassador/v2"
 )


### PR DESCRIPTION
We are currently waiting until the next update window for even considering to check if a reinstall/update could be done. So if a user changes some parameter in the spec (ie, the version from `version: 1.*` to `version: 2.*`) they will have to wait until maybe next Sunday 12pm
for seeing that change baing applied...

This change detects changes in the `.spec` in the `AmbassadorInstallation` (using the annotation where Kubernetes saves the last applied settings). If a change is detected, changes are applied immediately.

