### PR TITLE
Reconciliation fixes

### DIFF
--- a/ci/common.sh
+++ b/ci/common.sh
@@ -882,6 +882,16 @@ amb_restart() {
 	wait_deploy "$AMB_DEPLOY" $@
 }
 
+# returns the AES license as YAML
+amb_license_secret() {
+	kubectl get $@ secret ambassador-edge-stack -o yaml
+}
+
+# returns the AES license _data_ as it was saved with 'edgectl license _data_'
+amb_license_data() {
+	kubectl get $@ secret ambassador-edge-stack -o=jsonpath='{.data.license-key}' | base64 -d
+}
+
 ########################################################################################################################
 # AmbassadorInstallation
 ########################################################################################################################

--- a/pkg/controller/ambassadorinstallation/comp_test.go
+++ b/pkg/controller/ambassadorinstallation/comp_test.go
@@ -69,6 +69,49 @@ func TestHasChangedSpec(t *testing.T) {
 			hasChanged: false,
 		},
 		{
+			description: "changes not in the spec",
+			instance: stringToUnstr(`
+{
+    "apiVersion": "getambassador.io/v2",
+    "kind": "AmbassadorInstallation",
+    "metadata": {
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"getambassador.io/v2\",\"kind\":\"AmbassadorInstallation\",\"metadata\":{\"annotations\":{},\"name\":\"ambassador\",\"namespace\":\"ambassador\"},\"spec\":{\"helmValues\":{\"image\":{\"pullPolicy\":\"Always\"},\"namespace\":{\"name\":\"ambassador\"},\"service\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"targetPort\":8080}],\"type\":\"NodePort\"}},\"version\":\"1.*\"}}\n"
+        },
+        "creationTimestamp": "2020-05-28T09:12:59Z",
+        "generation": 3,
+        "name": "ambassador",
+        "namespace": "ambassador",
+        "resourceVersion": "1587",
+        "selfLink": "/apis/getambassador.io/v2/namespaces/ambassador/ambassadorinstallations/ambassador",
+        "uid": "f5e70521-837b-4891-84c1-2e713ae6e3da"
+    },
+    "spec": {
+        "helmValues": {
+            "image": {
+                "pullPolicy": "Always"
+            },
+            "namespace": {
+                "name": "ambassador"
+            },
+            "service": {
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": 80,
+                        "targetPort": 8080
+                    }
+                ],
+                "type": "NodePort"
+            }
+        },
+        "version": "1.*"
+    }
+}
+`),
+			hasChanged: false,
+		},
+		{
 			description: "changed version number to 2.*",
 			instance: stringToUnstr(`
 {

--- a/pkg/controller/ambassadorinstallation/reconcile.go
+++ b/pkg/controller/ambassadorinstallation/reconcile.go
@@ -47,6 +47,10 @@ var (
 	// some default Helm values
 	defaultChartValues = HelmValues{
 		"deploymentTool": "amb-oper",
+
+		"licenseKey": map[string]interface{}{
+			"createSecret": false,
+		},
 	}
 
 	// default image used for the OSS version
@@ -248,6 +252,9 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 
 	status.RemoveCondition(ambassador.ConditionIrreconcilable)
 
+	// check if the spec has changed before doing any modification to the AmbIns
+	specChanged := hasChangedSpec(ambIns)
+
 	// process all static Helm values: the default ones, the ones coming from files, etc...
 	helmValues := HelmValues{}
 	helmValues.AppendFrom(defaultChartValues, true) // copy the default values
@@ -399,7 +406,7 @@ func (r *ReconcileAmbassadorInstallation) Reconcile(request reconcile.Request) (
 	}
 
 	r.ReportEvent("completed_reconciliation")
-	return r.tryInstallOrUpdate(ambIns, chartsMgr, window, helmValuesStrings, isMigrating, flavor)
+	return r.tryInstallOrUpdate(ambIns, chartsMgr, window, helmValuesStrings, isMigrating, specChanged, flavor)
 }
 
 func (r *ReconcileAmbassadorInstallation) updateResource(o runtime.Object) error {

--- a/pkg/controller/ambassadorinstallation/reconcile_update.go
+++ b/pkg/controller/ambassadorinstallation/reconcile_update.go
@@ -35,7 +35,8 @@ const (
 
 // tryInstallOrUpdate checks if we need to update the Helm chart
 func (r *ReconcileAmbassadorInstallation) tryInstallOrUpdate(ambObj *unstructured.Unstructured,
-	chartsMgr HelmManager, window UpdateWindow, helmValues HelmValuesStrings, isMigrating bool, flavor string) (reconcile.Result, error) {
+	chartsMgr HelmManager, window UpdateWindow, helmValues HelmValuesStrings,
+	isMigrating bool, specChanged bool, flavor string) (reconcile.Result, error) {
 	updateDeadline := time.Now().Add(defaultUpdateTimeout)
 	ctx, _ := context.WithDeadline(context.TODO(), updateDeadline)
 
@@ -52,7 +53,12 @@ func (r *ReconcileAmbassadorInstallation) tryInstallOrUpdate(ambObj *unstructure
 	// 1) a migration from OSS to AES has been specified
 	// 2) the .spec has changed
 	ignoreTime := false
-	if isMigrating || hasChangedSpec(ambObj) {
+	if isMigrating {
+		log.Info("Migrating OSS->AES: we will ignore the last check time")
+		ignoreTime = true
+	}
+	if specChanged {
+		log.Info(".spec changes detected: we will ignore the last check time")
 		ignoreTime = true
 	}
 


### PR DESCRIPTION
* Do not even try to write the license.
* Check if the spec has changed as soon as we can, so we do not return false positives that lead to unnecessary reconciliations.

Closes #48 