### PR TITLE
Use different helmValues if an existing installation is detected

### DIFF
--- a/pkg/controller/ambassadorinstallation/charts.go
+++ b/pkg/controller/ambassadorinstallation/charts.go
@@ -19,6 +19,15 @@ var (
 	defHelmValuesFullPath = []string{"spec", defHelmValuesFieldName}
 )
 
+// there are two different "helm values":
+//
+// - regular helm values: they are typed, and can be expressed as a tree.
+// - "compact" (or string) values: they use the format used in `helm install --set`,
+//   separating nodes in a tree with dots. They are not typed, and the
+//   right side of the assignment is interpreted as a string.
+//
+// we must support the "compact" values for backwards compatibility
+
 // HelmValues is the values for the Helm chart
 type HelmValues map[string]interface{}
 
@@ -31,7 +40,7 @@ func GetHelmValuesAmbIns(ambIns *unstructured.Unstructured) HelmValues {
 	return helmValues
 }
 
-// Append appends all the `other` helm values
+// GetString gets a string value from the Helm values
 func (hv HelmValues) GetString(k string) (string, bool, error) {
 	ambIns := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -43,7 +52,7 @@ func (hv HelmValues) GetString(k string) (string, bool, error) {
 	return unstructured.NestedString(ambIns.Object, append(defHelmValuesFullPath, k)...)
 }
 
-// Append appends all the `other` helm values
+// AppendFrom appends all the `other` helm values
 func (hv *HelmValues) AppendFrom(other HelmValues, overwrite bool) {
 	for k, v := range other {
 		_, found := (*hv)[k]

--- a/tests/e2e/tests/01-install-uninstall.sh
+++ b/tests/e2e/tests/01-install-uninstall.sh
@@ -15,7 +15,7 @@ source "$this_dir/../common.sh"
 ########################################################################################################################
 
 # the versions of Ambassador to install
-AMB_VERSION="1.4.1"
+AMB_VERSION="1.6.0"
 
 # the managed-by we are expecting
 EXPECTED_MANAGED_BY="amb-oper-manifest"
@@ -58,13 +58,8 @@ passed "... good! /tmp/helm/values.yaml contains deploymentTool = $EXPECTED_MANA
 info "Checking we can install Ambassador..."
 amb_inst_apply_version "$AMB_VERSION" -n "$TEST_NAMESPACE" || failed "could not instruct the operator to install $AMB_VERSION"
 sleep 1
-info "Waiting for the Operator to install Ambassador"
-if ! wait_amb_addr -n "$TEST_NAMESPACE"; then
-	warn "Ambassador not installed. Dumping Operator's logs:"
-	oper_logs_dump -n "$TEST_NAMESPACE"
-	failed "could not get an Ambassador IP"
-fi
-passed "... good! Ambassador has been installed by the Operator!"
+
+oper_wait_install_amb -n "$TEST_NAMESPACE" || abort "the Operator did not install Ambassador"
 
 info "Checking that Ambassador has the managed-by == $EXPECTED_MANAGED_BY"
 sleep 10

--- a/tests/e2e/tests/02-custom-image.sh
+++ b/tests/e2e/tests/02-custom-image.sh
@@ -14,13 +14,13 @@ source "$this_dir/../common.sh"
 # local variables
 ########################################################################################################################
 
-# released images that will be used for tests
-CUSTOM_IMAGE_FIRST="${OFFICIAL_REGISTRY}/aes:1.3.0"
-CUSTOM_IMAGE_SECOND="${OFFICIAL_REGISTRY}/aes:1.4.0"
-
 # the versions of Ambassador to install
-IMAGE_TAG_FIRST="1.3.0"
-IMAGE_TAG_SECOND="1.4.0"
+IMAGE_TAG_FIRST="1.5.5"
+IMAGE_TAG_SECOND="1.6.0"
+
+# released images that will be used for tests
+CUSTOM_IMAGE_FIRST="${OFFICIAL_REGISTRY}/aes:${IMAGE_TAG_FIRST}"
+CUSTOM_IMAGE_SECOND="${OFFICIAL_REGISTRY}/aes:${IMAGE_TAG_SECOND}"
 
 ########################################################################################################################
 
@@ -39,13 +39,7 @@ info "Creating AmbassadorInstallation with baseImage=${CUSTOM_IMAGE_FIRST}..."
 apply_amb_inst_image ${CUSTOM_IMAGE_FIRST} -n "$TEST_NAMESPACE"
 info "AmbassadorInstallation created successfully..."
 
-info "Waiting for the Operator to install Ambassador"
-if ! wait_amb_addr -n "$TEST_NAMESPACE"; then
-	warn "Ambassador not installed. Dumping Operator's logs:"
-	oper_logs_dump -n "$TEST_NAMESPACE"
-	failed "could not get an Ambassador IP"
-fi
-passed "... good! Ambassador has been installed by the Operator!"
+oper_wait_install_amb -n "$TEST_NAMESPACE" || abort "the Operator did not install Ambassador"
 
 [ -n "$VERBOSE" ] && {
 	info "Describe: Ambassador Operator deployment:" && oper_describe -n "$TEST_NAMESPACE"

--- a/tests/e2e/tests/03-version-upgrade.sh
+++ b/tests/e2e/tests/03-version-upgrade.sh
@@ -15,7 +15,7 @@ source "$this_dir/../common.sh"
 ########################################################################################################################
 
 # the versions of Ambassador to install
-AMB_VERSION_FIRST="1.3.0"
+AMB_VERSION_FIRST="1.5.0"
 AMB_VERSION_SECOND_EXP="1.*"
 
 ########################################################################################################################
@@ -33,18 +33,7 @@ info "Installing Ambassador with version=${AMB_VERSION_FIRST}..."
 amb_inst_apply_version "$AMB_VERSION_FIRST" -n "$TEST_NAMESPACE" || failed "coud not instruct the operator to install ${AMB_VERSION_FIRST}"
 passed "... instructed the operator to install ${AMB_VERSION_FIRST}"
 
-info "Waiting for the Operator to install Ambassador"
-if ! wait_amb_addr -n "$TEST_NAMESPACE"; then
-	warn "Ambassador not installed. Dumping Operator's logs:"
-	oper_logs_dump -n "$TEST_NAMESPACE"
-	failed "could not get an Ambassador IP"
-fi
-passed "... good! Ambassador has been installed by the Operator!"
-
-[ -n "$VERBOSE" ] && {
-	info "Describe: Ambassador Operator deployment:" && oper_describe -n "$TEST_NAMESPACE"
-	info "Describe: Ambassador deployment:" && amb_describe -n "$TEST_NAMESPACE"
-}
+oper_wait_install_amb -n "$TEST_NAMESPACE" || abort "the Operator did not install Ambassador"
 
 info "Checking the version of Ambassador that has been deployed is $AMB_VERSION_FIRST..."
 if ! amb_check_image_tag "$AMB_VERSION_FIRST" -n "$TEST_NAMESPACE"; then

--- a/tests/e2e/tests/04-helm-install-uninstall.sh
+++ b/tests/e2e/tests/04-helm-install-uninstall.sh
@@ -15,7 +15,7 @@ source "$this_dir/../common.sh"
 ########################################################################################################################
 
 # the versions of Ambassador to install
-AMB_VERSION="1.4.1"
+AMB_VERSION="1.6.0"
 
 # the managed-by we are expecting
 EXPECTED_MANAGED_BY="amb-oper-helm"
@@ -43,18 +43,7 @@ passed "... good! /tmp/helm/values.yaml contains deploymentTool = $EXPECTED_MANA
 info "Checking we can install Ambassador..."
 amb_inst_apply_version "$AMB_VERSION" -n "$TEST_NAMESPACE" || failed "could not instruct the operator to install $AMB_VERSION"
 
-info "Waiting for the Operator to install Ambassador"
-if ! wait_amb_addr -n "$TEST_NAMESPACE"; then
-	warn "Ambassador not installed. Dumping Operator's logs:"
-	oper_logs_dump -n "$TEST_NAMESPACE"
-	failed "could not get an Ambassador IP"
-fi
-passed "... good! Ambassador has been installed by the Operator!"
-
-[ -n "$VERBOSE" ] && {
-	info "Describe: Ambassador Operator deployment:" && oper_describe -n "$TEST_NAMESPACE"
-	info "Describe: Ambassador deployment:" && amb_describe -n "$TEST_NAMESPACE"
-}
+oper_wait_install_amb -n "$TEST_NAMESPACE" || abort "the Operator did not install Ambassador"
 
 info "Checking that Ambassador has the managed-by == $EXPECTED_MANAGED_BY"
 sleep 10

--- a/tests/e2e/tests/05-install-oss.sh
+++ b/tests/e2e/tests/05-install-oss.sh
@@ -34,23 +34,7 @@ info "Creating AmbassadorInstallation with 'installOSS: true'..."
 apply_amb_inst_oss -n "$TEST_NAMESPACE"
 info "AmbassadorInstallation created successfully..."
 
-info "Waiting for the Operator to install Ambassador"
-if ! wait_amb_addr -n "$TEST_NAMESPACE"; then
-	warn "Ambassador not installed. Dumping Operator's logs:"
-	oper_logs_dump -n "$TEST_NAMESPACE"
-	failed "could not get an Ambassador IP"
-fi
-passed "... good! Ambassador has been installed by the Operator!"
-
-[ -n "$VERBOSE" ] && {
-	info "Describe: Ambassador Operator deployment:" && oper_describe -n "$TEST_NAMESPACE"
-	info "Describe: Ambassador deployment:" && amb_describe -n "$TEST_NAMESPACE"
-}
-
-[ -n "$VERBOSE" ] && {
-	info "Describe: Ambassador Operator deployment:" && oper_describe -n "$TEST_NAMESPACE"
-	info "Describe: Ambassador deployment:" && amb_describe -n "$TEST_NAMESPACE"
-}
+oper_wait_install_amb -n "$TEST_NAMESPACE" || abort "the Operator did not install Ambassador"
 
 info "Checking the repository of Ambassador that has been deployed is $IMAGE_REPOSITORY..."
 if ! amb_check_image_repository "$IMAGE_REPOSITORY" -n "$TEST_NAMESPACE"; then

--- a/tests/e2e/tests/06-install-with-values.sh
+++ b/tests/e2e/tests/06-install-with-values.sh
@@ -15,10 +15,10 @@ source "$this_dir/../common.sh"
 ########################################################################################################################
 
 # the versions of Ambassador to install
-AMB_VERSION="1.4.1"
+AMB_VERSION="1.6.0"
 
 # `image.tag` that will be forced in a helmvalue
-AMB_IMAGE_TAG="1.4.0"
+AMB_IMAGE_TAG="1.5.5"
 
 ########################################################################################################################
 
@@ -63,15 +63,7 @@ EOF
 #    service.ports[1].port: 443
 #    service.ports[1].targetPort: 8443
 
-info "Waiting for the Operator to install Ambassador"
-if ! wait_amb_addr -n "$TEST_NAMESPACE"; then
-	warn "It seems Ambassador was not installed:"
-	kubectl get deplokments -n $TEST_NAMESPACE
-	warn "Dumping Operator's logs:"
-	oper_logs_dump -n "$TEST_NAMESPACE"
-	failed "timeout while waiting for an Ambassador IP"
-fi
-passed "... good! Ambassador has been installed by the Operator!"
+oper_wait_install_amb -n "$TEST_NAMESPACE" || abort "the Operator did not install Ambassador"
 
 info "Checking Ambassador values:"
 values="$(helm get values -n "$TEST_NAMESPACE" ${AMB_INSTALLATION_NAME})"

--- a/tests/e2e/tests/08-migration-oss-aes-fail.sh
+++ b/tests/e2e/tests/08-migration-oss-aes-fail.sh
@@ -35,23 +35,7 @@ info "Creating AmbassadorInstallation with 'installOSS: true'..."
 apply_amb_inst_oss -n "$TEST_NAMESPACE"
 info "AmbassadorInstallation created successfully..."
 
-info "Waiting for the Operator to install Ambassador"
-if ! wait_amb_addr -n "$TEST_NAMESPACE"; then
-	warn "Ambassador not installed. Dumping Operator's logs:"
-	oper_logs_dump -n "$TEST_NAMESPACE"
-	failed "could not get an Ambassador IP"
-fi
-passed "... good! Ambassador has been installed by the Operator!"
-
-[ -n "$VERBOSE" ] && {
-	info "Describe: Ambassador Operator deployment:" && oper_describe -n "$TEST_NAMESPACE"
-	info "Describe: Ambassador deployment:" && amb_describe -n "$TEST_NAMESPACE"
-}
-
-[ -n "$VERBOSE" ] && {
-	info "Describe: Ambassador Operator deployment:" && oper_describe -n "$TEST_NAMESPACE"
-	info "Describe: Ambassador deployment:" && amb_describe -n "$TEST_NAMESPACE"
-}
+oper_wait_install_amb -n "$TEST_NAMESPACE" || abort "the Operator did not install Ambassador"
 
 info "Checking the repository of Ambassador that has been deployed is $IMAGE_REPOSITORY..."
 if ! amb_check_image_repository "$IMAGE_REPOSITORY" -n "$TEST_NAMESPACE"; then


### PR DESCRIPTION
* Use different helmValues if an existing installation is detected. In particular, do not create a license Secret if a previous installation is detected. This should not be necessary with recent Helm charts anyway, but it could fail when trying to install previous versions of the chart...
* Some e2e improvements

Fixes #59
